### PR TITLE
Add GNU Typist Installation Instruction for GNU User.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is "Collection of famous quotes in computer programming, software developme
 
 To install gnu-typist version 2.9 using Homebrew, you can run the following command in your terminal:
 
-```sh
-brew install gnu-typist
+```bash
+$ brew install gnu-typist
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This is "Collection of famous quotes in computer programming, software developme
 # Requirement
 - GNU Typist (any version should do, I tested with 2.9.x)
 
+## Intall GNU Typist using Homebrew
+
+To install gnu-typist version 2.9 using Homebrew, you can run the following command in your terminal:
+
+```sh
+brew install gnu-typist
+```
+
 # Usage
 ```bash
 # in the cloned directory

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is "Collection of famous quotes in computer programming, software developme
 # Requirement
 - GNU Typist (any version should do, I tested with 2.9.x)
 
-## Intall GNU Typist using Homebrew
+## Install GNU Typist using Homebrew
 
 To install gnu-typist version 2.9 using Homebrew, you can run the following command in your terminal:
 


### PR DESCRIPTION
To save users time and provide convenience, it is worthwhile to include instructions on how to install GNU Typist using Homebrew in the README. This will enable users to quickly set up GNU Typist without the need to search for installation steps on external sources.